### PR TITLE
생방송중인 채널 정보 보기 + 썸네일 주소 반환, 방송 보기를 클릭하면 m3u8파일의 cloudfront 주소를 반환하는 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,12 +34,18 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework:spring-webflux:6.1.2'
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
+//	runtimeOnly 'com.mysql:mysql-connector-j'
 	runtimeOnly 'io.asyncer:r2dbc-mysql'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.projectreactor:reactor-test'
+
+	implementation platform('software.amazon.awssdk:bom:2.21.1')
+	implementation 'software.amazon.awssdk:s3'
+	implementation 'software.amazon.awssdk:sso'
+	implementation 'software.amazon.awssdk:ssooidc'
 }
 
 test {

--- a/src/main/java/com/hanghae/lemonairservice/config/AwsConfig.java
+++ b/src/main/java/com/hanghae/lemonairservice/config/AwsConfig.java
@@ -1,0 +1,32 @@
+package com.hanghae.lemonairservice.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Configuration
+public class AwsConfig {
+	@Value("${aws.s3.credentials.accessKey}")
+	private String accessKey;
+
+	@Value("${aws.s3.credentials.secretKey}")
+	private String secretKey;
+
+	@Value("${aws.s3.region}")
+	private String region;
+
+	@Bean
+	public AmazonS3 amazonS3Client() {
+		AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+		return AmazonS3ClientBuilder.standard()
+			.withCredentials(new AWSStaticCredentialsProvider(credentials))
+			.withRegion(region)
+			.build();
+	}
+}

--- a/src/main/java/com/hanghae/lemonairservice/config/WebFluxConfig.java
+++ b/src/main/java/com/hanghae/lemonairservice/config/WebFluxConfig.java
@@ -1,0 +1,30 @@
+// package com.hanghae.lemonairservice.config;
+//
+// import org.springframework.boot.autoconfigure.web.reactive.WebFluxAutoConfiguration;
+// import org.springframework.context.annotation.Bean;
+// import org.springframework.context.annotation.Configuration;
+// import org.springframework.web.cors.CorsConfiguration;
+// import org.springframework.web.cors.reactive.CorsWebFilter;
+// import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
+// import org.springframework.web.reactive.config.CorsRegistry;
+// import org.springframework.web.reactive.config.EnableWebFlux;
+// import org.springframework.web.reactive.config.WebFluxConfigurer;
+//
+// @Configuration
+// public class WebFluxConfig implements WebFluxConfigurer {
+// 	@Bean
+// 	public CorsWebFilter corsWebFilter() {
+// 		CorsConfiguration corsConfig = new CorsConfiguration();
+// 		corsConfig.addAllowedOrigin("http://localhost:3000");
+// 		corsConfig.addAllowedMethod("GET");
+// 		corsConfig.addAllowedMethod("POST");
+// 		corsConfig.addAllowedMethod("PUT");
+// 		corsConfig.addAllowedMethod("DELETE");
+// 		corsConfig.addAllowedHeader("*");
+//
+// 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+// 		source.registerCorsConfiguration("/**", corsConfig);
+//
+// 		return new CorsWebFilter(source);
+// 	}
+// }

--- a/src/main/java/com/hanghae/lemonairservice/controller/MemberChannelController.java
+++ b/src/main/java/com/hanghae/lemonairservice/controller/MemberChannelController.java
@@ -1,0 +1,40 @@
+package com.hanghae.lemonairservice.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.hanghae.lemonairservice.dto.channel.MemberChannelDetailResponseDto;
+import com.hanghae.lemonairservice.dto.channel.MemberChannelResponseDto;
+import com.hanghae.lemonairservice.service.MemberChannelService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Controller
+@Slf4j
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@CrossOrigin
+public class MemberChannelController {
+	private final MemberChannelService memberChannelService;
+
+	@GetMapping("/channels")
+	public Mono<ResponseEntity<Flux<MemberChannelResponseDto>>> getChannelsByOnAirTrue() {
+
+		return memberChannelService.getChannelsByOnAirTrue();
+	}
+
+	@GetMapping("/channels/{channelId}")
+	public Mono<ResponseEntity<Mono<MemberChannelDetailResponseDto>>> getChannelDetail(
+		@PathVariable("channelId") Long channelId) {
+		Mono<ResponseEntity<Mono<MemberChannelDetailResponseDto>>> result = memberChannelService.getChannelDetail(
+			channelId);
+		return result;
+	}
+}

--- a/src/main/java/com/hanghae/lemonairservice/dto/channel/MemberChannelDetailResponseDto.java
+++ b/src/main/java/com/hanghae/lemonairservice/dto/channel/MemberChannelDetailResponseDto.java
@@ -1,0 +1,23 @@
+package com.hanghae.lemonairservice.dto.channel;
+
+import com.hanghae.lemonairservice.entity.MemberChannel;
+
+import lombok.Getter;
+
+@Getter
+public class MemberChannelDetailResponseDto {
+	private Long channelId;
+	private String streamer;
+	private String title;
+	private String hlsUrl;
+
+	public MemberChannelDetailResponseDto(MemberChannel memberChannel){
+		this.channelId = memberChannel.getId();
+		this.streamer = memberChannel.getStreamer();
+		this.title = memberChannel.getTitle();
+	}
+	public void updateHlsUrl(String hlsUrl){
+		this.hlsUrl= hlsUrl;
+	}
+
+}

--- a/src/main/java/com/hanghae/lemonairservice/dto/channel/MemberChannelResponseDto.java
+++ b/src/main/java/com/hanghae/lemonairservice/dto/channel/MemberChannelResponseDto.java
@@ -1,0 +1,21 @@
+package com.hanghae.lemonairservice.dto.channel;
+
+import com.hanghae.lemonairservice.entity.MemberChannel;
+
+import lombok.Getter;
+
+@Getter
+public class MemberChannelResponseDto {
+	private Long channelId;
+	private String streamer;
+	private String title;
+	private String thumbnailUrl;
+	public MemberChannelResponseDto(MemberChannel memberChannel){
+		this.channelId = memberChannel.getId();
+		this.streamer = memberChannel.getStreamer();
+		this.title = memberChannel.getTitle();
+	}
+	public void updateThumbnailUrl(String thumbnailUrl){
+		this.thumbnailUrl = thumbnailUrl;
+	}
+}

--- a/src/main/java/com/hanghae/lemonairservice/entity/MemberChannel.java
+++ b/src/main/java/com/hanghae/lemonairservice/entity/MemberChannel.java
@@ -1,0 +1,28 @@
+package com.hanghae.lemonairservice.entity;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Table("member_channel")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberChannel {
+	@Id
+	private Long id;
+	private String title;
+	private String streamer;
+	private Boolean onAir;
+
+	public MemberChannel(String nickname){
+		this.title = nickname + "의 방송";
+		this.streamer = nickname;
+		this.onAir = false;
+	}
+}

--- a/src/main/java/com/hanghae/lemonairservice/repository/MemberChannelRepository.java
+++ b/src/main/java/com/hanghae/lemonairservice/repository/MemberChannelRepository.java
@@ -1,0 +1,11 @@
+package com.hanghae.lemonairservice.repository;
+
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+
+import com.hanghae.lemonairservice.entity.MemberChannel;
+
+import reactor.core.publisher.Flux;
+
+public interface MemberChannelRepository extends ReactiveCrudRepository<MemberChannel, Long> {
+	Flux<MemberChannel> findAllByOnAirIsTrue();
+}

--- a/src/main/java/com/hanghae/lemonairservice/service/AwsService.java
+++ b/src/main/java/com/hanghae/lemonairservice/service/AwsService.java
@@ -1,0 +1,30 @@
+package com.hanghae.lemonairservice.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.amazonaws.services.s3.AmazonS3;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AwsService {
+	private final AmazonS3 amazonS3;
+
+	@Value("${aws.s3.bucket}")
+	private String bucket;
+
+	@Value("${aws.cloudfront.domain}")
+	private String cloudFrontDomain;
+
+	public String getThumbnailCloudFrontUrl(String streamerName) {
+		String key = streamerName + "/thumbnail/" + streamerName + "_thumbnail.jpg";
+		return cloudFrontDomain + amazonS3.getUrl(bucket, key).getPath();
+	}
+
+	public String getM3U8CloudFrontUrl(String streamerName) {
+		String key = streamerName + "/videos/" + "m3u8-" + streamerName + ".m3u8";
+		return cloudFrontDomain + amazonS3.getUrl(bucket, key).getPath();
+	}
+}

--- a/src/main/java/com/hanghae/lemonairservice/service/MemberChannelService.java
+++ b/src/main/java/com/hanghae/lemonairservice/service/MemberChannelService.java
@@ -1,0 +1,56 @@
+package com.hanghae.lemonairservice.service;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import com.hanghae.lemonairservice.dto.channel.MemberChannelDetailResponseDto;
+import com.hanghae.lemonairservice.dto.channel.MemberChannelResponseDto;
+import com.hanghae.lemonairservice.entity.MemberChannel;
+import com.hanghae.lemonairservice.repository.MemberChannelRepository;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class MemberChannelService {
+
+	private final AwsService awsService;
+	private final MemberChannelRepository memberChannelRepository;
+
+	public Mono<MemberChannel> createChannel(String nickname) {
+		return memberChannelRepository.save(new MemberChannel(nickname))
+			.onErrorResume(exception -> Mono.error(new RuntimeException("user의 channel 생성 오류")));
+
+	}
+
+	public Mono<ResponseEntity<Flux<MemberChannelResponseDto>>> getChannelsByOnAirTrue() {
+		Flux<MemberChannelResponseDto> memberChannelResponseDtoFlux = memberChannelRepository.findAllByOnAirIsTrue()
+			.map(MemberChannelResponseDto::new)
+			.doOnNext(this::updateThumbnailUrl);
+
+		return Mono.just(ResponseEntity.ok(memberChannelResponseDtoFlux));
+	}
+
+	private void updateThumbnailUrl(MemberChannelResponseDto memberChannelResponseDto) {
+		memberChannelResponseDto.updateThumbnailUrl(
+			awsService.getThumbnailCloudFrontUrl(memberChannelResponseDto.getStreamer()));
+	}
+
+	// TODO: 2023-12-17 postman에서만 빈 mono가 return되는건지 확인해볼 필요가 있다.
+	public Mono<ResponseEntity<Mono<MemberChannelDetailResponseDto>>> getChannelDetail(Long channelId) {
+		return memberChannelRepository.findById(channelId)
+			.switchIfEmpty(Mono.error(new RuntimeException("해당 방송이 존재하지 않습니다.")))
+			.filter(MemberChannel::getOnAir)
+			.switchIfEmpty(Mono.error(new RuntimeException("해당 방송은 종료되었습니다.")))
+			.map(MemberChannelDetailResponseDto::new)
+			.doOnNext(this::updateM3U8Url)
+			.map(memberChannelDetailResponseDto -> ResponseEntity.ok(Mono.just(memberChannelDetailResponseDto)));
+	}
+
+	private void updateM3U8Url(MemberChannelDetailResponseDto memberChannelDetailResponseDto) {
+		memberChannelDetailResponseDto.updateHlsUrl(
+			awsService.getM3U8CloudFrontUrl(memberChannelDetailResponseDto.getStreamer()));
+	}
+}

--- a/src/main/resources/application-common.yaml
+++ b/src/main/resources/application-common.yaml
@@ -1,0 +1,15 @@
+spring:
+  r2dbc:
+    url: r2dbc:mysql://localhost:3306/streamtest?serverTimezone=UTC+9
+    username: root
+    password: 12345678
+
+logging:
+  level:
+    org.springframework.r2dbc.core: debug
+
+jwt:
+  secretKey: ${JWT_SECRET_KEY}
+
+server:
+  port: 8081

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,16 +1,8 @@
 spring:
-  r2dbc:
-    url: r2dbc:mysql://localhost:3306/streamtest?serverTimezone=UTC+9
-    username: root
-    password: 12345678
-
-
-logging:
-  level:
-    org.springframework.r2dbc.core: debug
-
-jwt:
-  secretKey: ${JWT_SECRET_KEY}
-
-server:
-  port: 8081
+  profiles:
+    group:
+      local:
+    include:
+      - secret
+      - common
+    active: local

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -7,3 +7,11 @@ CREATE TABLE member
     nickname   VARCHAR(255) NOT NULL UNIQUE,
     stream_key VARCHAR(255) NOT NULL UNIQUE
 );
+
+CREATE TABLE member_channel
+(
+    id          SERIAL PRIMARY KEY,
+    title       VARCHAR(255) NOT NULL UNIQUE,
+    streamer    VARCHAR(255) NOT NULL,
+    on_air      BOOLEAN NOT NULL
+);


### PR DESCRIPTION
MemberChannelController.getChannelsByOnAirTrue() 전체 생방송 채널 정보보기 기능은 포스트맨에서 테스트되었는데,

MemberChannelController.getChannelDetail() 메서드는 테스트 결과 비어있는 모노가 리턴되는 상황입니다.
